### PR TITLE
returns false if mail doesnt send

### DIFF
--- a/suzie/Mailer.php
+++ b/suzie/Mailer.php
@@ -42,7 +42,11 @@ class Mailer
             $args['from'] = getenv('MAILGUN_FROM');
         }
 
-        $this->mailgun->sendMessage($this->domain, $args, $attachments);
+        try {
+            return $this->mailgun->sendMessage($this->domain, $args, $attachments);
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 
     /**
@@ -182,6 +186,6 @@ class Mailer
     {
         $suzieMailer = new self();
         list($args, $attachments) = call_user_func_array([$suzieMailer, 'fetchArguments'], func_get_args());
-        $suzieMailer->send($args, $attachments);
+        return $suzieMailer->send($args, $attachments);
     }
 }

--- a/suzie/bootstrap/app.php
+++ b/suzie/bootstrap/app.php
@@ -19,7 +19,7 @@ Dotenv::load($rootPath);
  */
 function wp_mail($to, $subject, $message, $headers = '', $attachments = [])
 {
-    Suzie\Mailer::boot($to, $subject, $message, $headers, $attachments);
+    return Suzie\Mailer::boot($to, $subject, $message, $headers, $attachments);
 }
 
 function suzie()


### PR DESCRIPTION
This caused issues with contact form 7 due to it relying on wp_mail returning true when sending mail
