### PR TITLE
Updates to wp-config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 APP_ENV=local
-APP_KEY=
+APP_KEY=xxxxxxxxxxxx
 
 DB_NAME=suzie
 DB_USER=root

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,6 @@ DB_HOST=localhost
 DB_PREFIX=wp_
 
 WP_DEBUG=true
-WP_LOCAL_DEV=true
 WP_FORCE_SSL=false
 
 SITE_URL=http://domain.com

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 APP_ENV=local
+APP_KEY=
 
 DB_NAME=suzie
 DB_USER=root

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
 APP_ENV=local
-APP_KEY=6goBCImVkVsv
 
 DB_NAME=suzie
 DB_USER=root

--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -60,16 +60,17 @@ define('DB_COLLATE', '');
 
 /**
  * Authentication unique keys and salts.
- * Generate these at: https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service
+ *
+ * @link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service
  */
-define('AUTH_KEY',         'Y67764N;I5-:2|DO!GPAP#B>8Ni:bLbI6(`Wuq)!j|H7JG+[Y/-4`+11mAW9XgSn');
-define('SECURE_AUTH_KEY',  '2uxhUWw$-kb)qA1.(Y/E2Q>,??2?hqN=_gDXt&X(]JF@U(WPj,]#YZS->,P!t5 p');
-define('LOGGED_IN_KEY',    'fB?)5ZaBLP*>!-9;8`em:-1_8_SGy17@-|7{0Q30#rJwtD>Iy11-t|60dx8h<tN^');
-define('NONCE_KEY',        'Pu8MkPU?Dytqth*O]hTbh|pg(H6zs|7L[j%OE-WjtGqkb0:p}yYIXZ!<P>fFmHZ:');
-define('AUTH_SALT',        'hI2Acz>?PljC#kA:ryzZ]H+>vOy%]|D#2y5Y>A::k|ec5[Mfq#[ Zdh}knZV,7l(');
-define('SECURE_AUTH_SALT', 'fV+VLHo5~W|;]0pFCoiLi-{8WhMgUU+Z31|&-6+T`E$vr~~q!S570%=QPz^9?7E[');
-define('LOGGED_IN_SALT',   'JVG}(FNqhQA1z3-6zZ%D5o[Kqn+$_0~ja0S_s>$8=#qZcy(w#OMnuS86PVJsOP/q');
-define('NONCE_SALT',       'L-A0er+ibw}s03sIp}dGeGu[!##sV_0Gt~OsZy8`K-DW(:_<D1GD?!*77J>h}(V&');
+define('AUTH_KEY',         'put your unique phrase here');
+define('SECURE_AUTH_KEY',  'put your unique phrase here');
+define('LOGGED_IN_KEY',    'put your unique phrase here');
+define('NONCE_KEY',        'put your unique phrase here');
+define('AUTH_SALT',        'put your unique phrase here');
+define('SECURE_AUTH_SALT', 'put your unique phrase here');
+define('LOGGED_IN_SALT',   'put your unique phrase here');
+define('NONCE_SALT',       'put your unique phrase here');
 
 /**
  * WordPress database table prefix.

--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -1,27 +1,26 @@
 <?php
-
 /**
- * Set root path
+ * Set root path.
  */
 $rootPath = realpath(__DIR__ . '/..');
 
 /**
- * Include the Composer autoload
+ * Include the Composer autoloader.
  */
 include $rootPath . '/vendor/autoload.php';
 
 /**
- * Set URL
+ * Set site URL.
  */
 $server_url = getenv('SITE_URL');
 
 /**
- * Define in environment
+ * Define environment.
  */
-define('APP_ENV',     getenv('APP_ENV'));
+define('APP_ENV', getenv('APP_ENV'));
 
 /**
- * Set Database Details
+ * Set database details.
  */
 define('DB_NAME',     getenv('DB_NAME'));
 define('DB_USER',     getenv('DB_USER'));
@@ -29,39 +28,38 @@ define('DB_PASSWORD', getenv('DB_PASSWORD'));
 define('DB_HOST',     getenv('DB_HOST'));
 
 /**
- * Set debug modes
+ * Set debug mode.
  */
-define('WP_DEBUG', getenv('WP_DEBUG') === 'true'? true: false);
-define('WP_LOCAL_DEV', getenv('WP_LOCAL_DEV') === 'true'? true: false);
+define('WP_DEBUG', getenv('WP_DEBUG') === 'true' ? true : false);
 
 /**
- * SSL
+ * SSL.
  */
-define('FORCE_SSL_ADMIN', getenv('WP_FORCE_SSL') === 'true'? true: false);
-define('FORCE_SSL_LOGIN', getenv('WP_FORCE_SSL') === 'true'? true: false);
-if ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
-    $_SERVER['HTTPS']='on';
+define('FORCE_SSL_ADMIN', getenv('WP_FORCE_SSL') === 'true' ? true : false);
+define('FORCE_SSL_LOGIN', getenv('WP_FORCE_SSL') === 'true' ? true : false);
+
+if ($_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https')
+{
+    $_SERVER['HTTPS'] = 'on';
 }
 
 /**
- * Set custom paths
- * These are required because wordpress is installed in a subdirectory
+ * Set custom paths.
+ * These are required because WordPress is installed in a subdirectory.
  */
 define('WP_CONTENT_URL', $server_url . '/content');
 define('WP_SITEURL',     $server_url . '/wordpress');
 define('WP_HOME',        $server_url . '/');
 define('WP_CONTENT_DIR', __DIR__ . '/content');
 
-
 /**
- * Usual Wordpress stuff - Dont overide the ones you have already
+ * Usual Wordpress stuff - don't overide the ones you have already.
  */
 define('DB_CHARSET', 'utf8');
 define('DB_COLLATE', '');
 
-
 /**
- * Authentication Unique Keys and Salts
+ * Authentication unique keys and salts.
  * Generate these at: https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service
  */
 define('AUTH_KEY',         'Y67764N;I5-:2|DO!GPAP#B>8Ni:bLbI6(`Wuq)!j|H7JG+[Y/-4`+11mAW9XgSn');
@@ -73,42 +71,49 @@ define('SECURE_AUTH_SALT', 'fV+VLHo5~W|;]0pFCoiLi-{8WhMgUU+Z31|&-6+T`E$vr~~q!S57
 define('LOGGED_IN_SALT',   'JVG}(FNqhQA1z3-6zZ%D5o[Kqn+$_0~ja0S_s>$8=#qZcy(w#OMnuS86PVJsOP/q');
 define('NONCE_SALT',       'L-A0er+ibw}s03sIp}dGeGu[!##sV_0Gt~OsZy8`K-DW(:_<D1GD?!*77J>h}(V&');
 
-
 /**
- * WordPress Database Table prefix
- * Use something other than `wp_` for security
+ * WordPress database table prefix.
+ * Use something other than `wp_` for security.
  */
-$table_prefix  = getenv('DB_PREFIX');
+$table_prefix = getenv('DB_PREFIX');
 
 /**
- * WordPress Localized Language, defaults to English.
+ * WordPress localized language, defaults to English.
  */
 define('WPLANG', '');
 
-
 /**
- * Absolute path to the WordPress directory
+ * Absolute path to the WordPress directory.
  */
 if (!defined('ABSPATH'))
+{
     define('ABSPATH', dirname(__FILE__) . '/');
+}
 
 /**
- * Suzie
- * use {theme} or {plugin}
+ * Suzie settings.
+ * Use {theme} or {plugin} for directory paths.
  */
-define('SUZIE_CDN_THEME', 'theme-name' );
+
+// Set theme name for CDN.
+define('SUZIE_CDN_THEME', 'theme-name');
+
+// Assets to send to CDN.
 define('SUZIE_CDN_ASSETS', json_encode([
 
 ]));
+
+// Folders to send to CDN.
 define('SUZIE_CDN_FOLDERS', json_encode([
 
 ]));
 
-// Sets up WordPress vars and included files
+// Sets up WordPress vars and included files.
 if (defined('DOING_CDN'))
+{
     return;
+}
 
 require_once(ABSPATH . 'wp-settings.php');
 
 suzie();
-

--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -78,11 +78,6 @@ define('NONCE_SALT',       'L-A0er+ibw}s03sIp}dGeGu[!##sV_0Gt~OsZy8`K-DW(:_<D1GD
 $table_prefix = getenv('DB_PREFIX');
 
 /**
- * WordPress localized language, defaults to English.
- */
-define('WPLANG', '');
-
-/**
  * Absolute path to the WordPress directory.
  */
 if (!defined('ABSPATH'))


### PR DESCRIPTION
- Removed `WP_LOCAL_DEV`, not a standard WP variable — use existing `APP_ENV` for environment variables in the `.env` file`
- Removed `WPLANG`, as it's blank and the standard WP config doesn't have it in
- Removed auth keys
- Remove `APP_KEY` in `.env` file has it has no use for WordPress
- Tidied it up a little
