### PR TITLE
Use https for the composer repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "repositories": [
     {
       "type": "composer",
-      "url": "http://wpackagist.org"
+      "url": "https://wpackagist.org"
     }
   ],
   "autoload": {


### PR DESCRIPTION
I got an error trying to use suzie for the first time.

```
$ composer install
Loading composer repositories with package information

  [Composer\Downloader\TransportException]
  Your configuration does not allow connection to http://wpackagist.org. See https://getcomposer.org/doc/06-config.md#secure-http for details
  .
```
