### PR TITLE
[fix] Fixed issue with wpackagist themes path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
   },
   "extra": {
     "installer-paths": {
-      "public/content/plugins/{$name}/": ["type:wordpress-plugin"]
+      "public/content/plugins/{$name}/": ["type:wordpress-plugin"],
+      "public/content/themes/{$name}/": ["type:wordpress-theme"]
     },
     "wordpress-install-dir": "public/wordpress"
   },


### PR DESCRIPTION
Fixed an issue when installing a theme from wpackagist.org - it would not move it to the correct place.
This is a problem for child themes particualry because they break when the parent isn't in the right place.
